### PR TITLE
Skru av 'OmitStackTraceInFastThrow'.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,4 +12,5 @@
   :profiles {:dev {:dependencies [[midje "1.6.3"]]
                    :plugins [[lein-midje "3.1.1"]]
                    :resource-paths ["test-resources"]}
-             :uberjar {:aot [clojure-workshop.cat]}})
+             :uberjar {:aot [clojure-workshop.cat]}}
+  :jvm-opts ["-XX:-OmitStackTraceInFastThrow"])


### PR DESCRIPTION
Slik at stacktraces blir bevart i e.g. NPEs.

Merger du over i master også?
